### PR TITLE
Revert back to building oldest builds first, so the build numbers make sense

### DIFF
--- a/config_helper.py
+++ b/config_helper.py
@@ -14,13 +14,7 @@
 #
 # Helper code for the Open Lighting Project buildbot configs.
 
-import operator
 import os
-
-def pickLatestBuild(builder, requests): 
-  """Build most recent builds first, from webkit's buildbot config"""
-  return max(requests, key=operator.attrgetter("submittedAt")) 
-
 
 def LoadConfig(config_file):
   """Load the buildbot config from a config file."""

--- a/master.cfg
+++ b/master.cfg
@@ -194,10 +194,7 @@ for slave in slaves.GetSlaves(config_helper.HasBuild):
                     factory=factory,
                     #Slow slaves will merge requests, to try and reduce their
                     #Workload
-                    mergeRequests=slave.is_slow,
-                    #Build most recent commits first, to make better use of CPU
-                    #time and get quicker indication of failure
-                    nextBuild=config_helper.pickLatestBuild))
+                    mergeRequests=slave.is_slow))
 
 cpp_lint_slaves = slaves.GetSlaves(config_helper.HasCPPLintFilter)
 if cpp_lint_slaves:


### PR DESCRIPTION
Will try and improve performance using isFileImportant instead.
