### PR TITLE
Stop caring about warnings during make builtfiles

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -214,7 +214,6 @@ ola_doc_factory.addStep(Compile(
     name='make builtfiles',
     description='generating built files',
     descriptionDone='generated built files',
-    flunkOnWarnings=True,
     command=['make', 'builtfiles']))
 ola_doc_factory.addStep(Compile(
     name='make doxygen-doc',
@@ -255,7 +254,6 @@ ja_rule_doc_factory.addStep(ShellCommand(
 #     name='make builtfiles',
 #     description='generating built files',
 #     descriptionDone='generated built files',
-#     flunkOnWarnings=True,
 #     command=['make', 'builtfiles']))
 ja_rule_doc_factory.addStep(Compile(
     name='make doxygen-doc',


### PR DESCRIPTION
So we don't get spurious errors from:
./tools/ola_trigger/config.ypp: warning: 1 shift/reduce conflict [-Wconflicts-sr]