### PR TITLE
Revert "Remove ola tahr buildslave."

### DIFF
--- a/build.config
+++ b/build.config
@@ -117,7 +117,8 @@ SLAVES = {
       Slave('noopenslp', has_cpp_lint=True, has_tcmalloc=True),  # Simon
     ],
     'x86_64': [
-      Slave('noopenslp', has_cpp_lint=True, has_js_lint=True, has_tcmalloc=True),  # RenZO
+      Slave('noopenslp', has_cpp_lint=True, has_js_lint=True,
+            has_tcmalloc=True),  # RenZO
     ],
   }
 }

--- a/build.config
+++ b/build.config
@@ -116,6 +116,9 @@ SLAVES = {
     'i686': [
       Slave('noopenslp', has_cpp_lint=True, has_tcmalloc=True),  # Simon
     ],
+    'x86_64': [
+      Slave('noopenslp', has_cpp_lint=True, has_js_lint=True, has_tcmalloc=True),  # RenZO
+    ],
   }
 }
 


### PR DESCRIPTION
Still available and on when the *BSDs are.