### PR TITLE
Start building the Ja Rule user manual

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -232,10 +232,10 @@ ola_doc_factory.addStep(Compile(
     flunkOnWarnings=True,
     command=['make', 'doxygen-doc']))
 ola_doc_factory.addStep(ShellCommand(
-  workdir="build",
-  command=["./doxygen/copy-doc.sh",
-           "/opt/www/docs.openlighting.org/ola/doc/latest/"],
-  name="copy"))
+    workdir="build",
+    command=["./doxygen/copy-doc.sh",
+             "/opt/www/docs.openlighting.org/ola/doc/latest/"],
+    name="copy"))
 
 # OLA man page factory
 ola_man_factory = BuildFactory()
@@ -272,9 +272,43 @@ ja_rule_doc_factory.addStep(Compile(
     flunkOnWarnings=True,
     command=['make', 'doxygen-doc']))
 ja_rule_doc_factory.addStep(ShellCommand(
-  command=["./doxygen/copy-doc.sh",
-           "/opt/www/docs.openlighting.org/ja-rule/doc/latest/"],
-  name="copy"))
+    command=["./doxygen/copy-doc.sh",
+             "/opt/www/docs.openlighting.org/ja-rule/doc/latest/"],
+    name="copy"))
+
+# Ja-Rule doxygen manual factory
+ja_rule_manual_factory = BuildFactory()
+ja_rule_manual_factory.addStep(Git(
+    repourl=BuildRepoURL(config['JA_RULE_REPO'])
+))
+ja_rule_manual_factory.addStep(ShellCommand(command=["./install-gmock.sh"],
+                                            name="install gmock"))
+ja_rule_manual_factory.addStep(ShellCommand(command=["autoreconf", "-i"],
+                                            name="autoreconf"))
+# Should be able to switch to these with newer versions of buildbot
+# ja_rule_manual_factory.addStep(Configure(
+#     command=["./configure", "--disable-doxygen-version", "--without-ola"]))
+ja_rule_manual_factory.addStep(ShellCommand(
+    command=["./configure", "--disable-doxygen-version", "--without-ola"],
+    name="configure",
+))
+# ja_rule_manual_factory.addStep(Compile(
+#     name='make builtfiles',
+#     description='generating built files',
+#     descriptionDone='generated built files',
+#     command=['make', 'builtfiles']))
+ja_rule_manual_factory.addStep(Compile(
+    workdir="build/user_manual",
+    name='doxygen',
+    description='documenting',
+    descriptionDone='documented',
+    flunkOnWarnings=True,
+    command=['doxygen']))
+ja_rule_manual_factory.addStep(ShellCommand(
+    workdir="build/user_manual",
+    command=["./copy-manual.sh",
+             "/opt/www/docs.openlighting.org/ja-rule/manual/latest/"],
+    name="copy"))
 
 c['builders'] = []
 
@@ -373,6 +407,14 @@ if ja_rule_doc_slaves:
       BuilderConfig(name="doxygen-doc-generator-ja-rule",
                     slavenames=[s.name() for s in ja_rule_doc_slaves],
                     factory=ja_rule_doc_factory,
+                    tags=['ja-rule', ("ja-rule-%s" %
+                                      config['JA_RULE_TRUNK_NAME'])]))
+  builder_branches['ja_rule'][config['JA_RULE_TRUNK_NAME']].append(
+      "doxygen-manual-generator-ja-rule")
+  c['builders'].append(
+      BuilderConfig(name="doxygen-manual-generator-ja-rule",
+                    slavenames=[s.name() for s in ja_rule_doc_slaves],
+                    factory=ja_rule_manual_factory,
                     tags=['ja-rule', ("ja-rule-%s" %
                                       config['JA_RULE_TRUNK_NAME'])]))
 


### PR DESCRIPTION
This is blocked behind changes in https://github.com/OpenLightingProject/ja-rule/pull/256 . Well it could go in, but the builder won't fully work until those changes are merged.