### PR TITLE
Work around issues where reconfig fails due to our python code having changed

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -13,7 +13,7 @@ if [ -n "$output" ]; then
   $BUILDBOT checkconfig master.cfg
   # checkconfig exits 0 if everything is ok.
   if [ $? -eq 0 ]; then
-    $BUILDBOT reconfig
+    $BUILDBOT reconfig || $BUILDBOT restart
   else
     echo "Buildbot config is bad";
   fi;


### PR DESCRIPTION
Needs testing still.

For example https://github.com/OpenLightingProject/buildbot/pull/65 broke this

See the warning at http://docs.buildbot.net/0.8.12/manual/cfg-intro.html?highlight=reconfig#reloading-the-config-file-reconfig